### PR TITLE
fix `--output`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ Bulk replace GitHub Actions references from version tags to commit hashes for lo
 You can install it using the following command:
 
 ```sh
-go install github.com/mashiike/actionspin@latest
+$go install github.com/mashiike/actionspin/cmd/actionspin@latest 
 ```
 
 Alternatively, you can download the binary from [GitHub Releases](https://github.com/mashiike/actionspin/releases).
+
+or, Homebrew:
+
+```sh
+$ brew install mashiike/tap/actionspin
+```
 
 ## Usage
 

--- a/app.go
+++ b/app.go
@@ -25,7 +25,7 @@ type App struct {
 
 type AppOptions struct {
 	Target             string                                                             `help:"Replace Target dir or file" required:"" type:"existingpath" default:".github"`
-	Output             string                                                             `help:"Output dir" type:"path" default:""`
+	Output             string                                                             `help:"Output dir" type:"path" default:"-"`
 	GithubToken        string                                                             `help:"GitHub token" env:"GITHUB_TOKEN"`
 	CommitHashResolver func(ctx context.Context, owner, repo, ref string) (string, error) `kong:"-"`
 }
@@ -34,8 +34,10 @@ func New(opts AppOptions) *App {
 	if opts.CommitHashResolver == nil {
 		opts.CommitHashResolver = DefaultCommitHashResolver(opts.GithubToken)
 	}
-	if opts.Output == "" {
+	slog.Debug("AppOptions", "target", opts.Target, "output", opts.Output)
+	if opts.Output == "" || opts.Output == "-" {
 		opts.Output = opts.Target
+		slog.Debug("Output is not set, use Target as Output", "output", opts.Output)
 	}
 	return &App{
 		opts:          opts,


### PR DESCRIPTION
This pull request includes several changes to improve the installation instructions in the `README.md` file and enhance the `App` struct in the `app.go` file. The most important changes are summarized below:

### Documentation Improvements:
* Updated the `README.md` file to include Homebrew installation instructions for `actionspin`.

### Code Enhancements:
* Modified the `Output` field in the `AppOptions` struct to use `"-"` as the default value instead of an empty string.
* Added debug logging in the `New` function to log the `AppOptions` and handle cases where `Output` is not set or is `"-"`.