### PR TITLE
fix quate case

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -35,6 +35,7 @@ func TestApp_Run(t *testing.T) {
 		"workflows/test.yaml",
 		"workflows/workflow1.yaml",
 		"workflows/workflow2.yaml",
+		"workflows/workflow3.yaml",
 	}
 	replacedFiles := app.ReplacedFiles()
 	require.ElementsMatch(t, expectedFiles, replacedFiles)

--- a/testdata/.github/workflows/workflow3.yaml
+++ b/testdata/.github/workflows/workflow3.yaml
@@ -1,0 +1,8 @@
+name: Workflow 2
+on: pull_request
+jobs:
+  job2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node
+        uses: "actions/setup-node@v1"

--- a/testdata/fixture/workflows/workflow3.yaml
+++ b/testdata/fixture/workflows/workflow3.yaml
@@ -1,0 +1,8 @@
+name: Workflow 2
+on: pull_request
+jobs:
+  job2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node
+        uses: "actions/setup-node@mockedCommitHash" # v1


### PR DESCRIPTION
before this pr

```diff
--- a/.github/workflows/test.yaml        2025-03-18 11:41:16
+++ b/.github/workflows/test.yaml        2025-03-18 14:36:32
@@ -20,13 +20,13 @@
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: "actions/setup-go@v5"
+        uses: "actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5"
         with:
           go-version: ${{ matrix.go }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4"
 
       - name: Build & Test
         run: |
```

fix this:

```diff
--- a/.github/workflows/test.yaml        2025-03-18 11:41:16
+++ b/.github/workflows/test.yaml        2025-03-18 14:36:32
@@ -20,13 +20,13 @@
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: "actions/setup-go@v5"
+        uses: "actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34" # v5
         with:
           go-version: ${{ matrix.go }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4
 
       - name: Build & Test
         run: |
```
