### PR TITLE
Add GitHub Enterprise Server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Flags:
       --target=".github"       Replace Target dir or file
       --output=""              Output dir
       --github-token=STRING    GitHub token ($GITHUB_TOKEN)
+      --ghe-host=STRING        GitHub Enterprise Server host ($GHE_HOST)
+      --ghe-token=STRING       GitHub Enterprise Server token ($GHE_TOKEN)
 ```
 
 For example, consider the following Actions workflow:
@@ -131,6 +133,25 @@ jobs:
         run: |
           go test -race ./... -timeout 30s
 ```
+
+### GitHub Enterprise Server Support
+
+`actionspin` now supports GitHub Enterprise Server (GHES). When working with both GitHub.com and GHES repositories, you can configure the tool to resolve action references from your enterprise instance:
+
+```sh
+# Using environment variables
+export GHE_HOST=github.example.com
+export GHE_TOKEN=ghp_enterprise_token
+actionspin
+
+# Or using command line flags
+actionspin --ghe-host=github.example.com --ghe-token=ghp_enterprise_token
+```
+
+When GHES configuration is provided, `actionspin` will:
+1. First attempt to resolve action references from your GitHub Enterprise Server instance
+2. Fall back to GitHub.com if the action is not found on GHES
+3. This allows seamless operation with mixed environments where some actions are hosted on GHES and others on GitHub.com
 
 ## Contributing
 

--- a/app.go
+++ b/app.go
@@ -24,15 +24,25 @@ type App struct {
 }
 
 type AppOptions struct {
-	Target             string                                                             `help:"Replace Target dir or file" required:"" type:"existingpath" default:".github"`
-	Output             string                                                             `help:"Output dir" type:"path" default:"-"`
-	GithubToken        string                                                             `help:"GitHub token" env:"GITHUB_TOKEN"`
-	CommitHashResolver func(ctx context.Context, owner, repo, ref string) (string, error) `kong:"-"`
+	Target             string             `help:"Replace Target dir or file" required:"" type:"existingpath" default:".github"`
+	Output             string             `help:"Output dir" type:"path" default:"-"`
+	GithubToken        string             `help:"GitHub token" env:"GITHUB_TOKEN"`
+	GHEHost            string             `help:"GitHub Enterprise Server host" name:"ghe-host" env:"GHE_HOST"`
+	GHEToken           string             `help:"GitHub Enterprise Server token" name:"ghe-token" env:"GHE_TOKEN"`
+	CommitHashResolver CommitHashResolver `kong:"-"`
 }
 
 func New(opts AppOptions) *App {
 	if opts.CommitHashResolver == nil {
-		opts.CommitHashResolver = DefaultCommitHashResolver(opts.GithubToken)
+		if opts.GHEHost != "" {
+			resolvers := []CommitHashResolver{
+				GHECommitHashResolver(opts.GHEHost, opts.GHEToken),
+				DefaultCommitHashResolver(opts.GithubToken),
+			}
+			opts.CommitHashResolver = FallbackCommitHashResolver(resolvers)
+		} else {
+			opts.CommitHashResolver = DefaultCommitHashResolver(opts.GithubToken)
+		}
 	}
 	slog.Debug("AppOptions", "target", opts.Target, "output", opts.Output)
 	if opts.Output == "" || opts.Output == "-" {
@@ -235,13 +245,53 @@ type Step struct {
 	Uses string `yaml:"uses"`
 }
 
-func DefaultCommitHashResolver(token string) func(ctx context.Context, owner, repo, ref string) (string, error) {
+type CommitHashResolver func(ctx context.Context, owner, repo, ref string) (string, error)
+
+func DefaultCommitHashResolver(token string) CommitHashResolver {
 	var client *github.Client
 	if token != "" {
 		client = github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})))
 	} else {
 		client = github.NewClient(nil)
 	}
+	return newCommitHashResolver(client)
+}
+
+func GHECommitHashResolver(ghHost, token string) CommitHashResolver {
+	var client *github.Client
+	if token != "" {
+		client = github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})))
+	} else {
+		client = github.NewClient(nil)
+	}
+	var err error
+	baseURL := fmt.Sprintf("https://%s/api/v3/", ghHost)
+	uploadURL := fmt.Sprintf("https://%s/api/uploads/", ghHost)
+	client, err = client.WithEnterpriseURLs(baseURL, uploadURL)
+	if err != nil {
+		// If there is an error creating the client, return a function that always returns the error.
+		return func(ctx context.Context, owner, repo, ref string) (string, error) {
+			return "", fmt.Errorf("failed to create client for GitHub Enterprise Server: %w", err)
+		}
+	}
+	return newCommitHashResolver(client)
+}
+
+func FallbackCommitHashResolver(funcs []CommitHashResolver) CommitHashResolver {
+	return func(ctx context.Context, owner, repo, ref string) (string, error) {
+		for _, fn := range funcs {
+			commitHash, err := fn(ctx, owner, repo, ref)
+			if err == nil {
+				return commitHash, nil
+			} else {
+				slog.WarnContext(ctx, "failed to resolve commit hash, try next resolver", "owner", owner, "repo", repo, "ref", ref, "error", err)
+			}
+		}
+		return "", fmt.Errorf("all commit hash resolvers failed for %s/%s@%s", owner, repo, ref)
+	}
+}
+
+func newCommitHashResolver(client *github.Client) CommitHashResolver {
 	return func(ctx context.Context, owner, repo, ref string) (string, error) {
 		// First, try resolving as a branch reference.
 		branchRef, _, err := client.Git.GetRef(ctx, owner, repo, "refs/heads/"+ref)


### PR DESCRIPTION
- Add --ghe-host and --ghe-token flags
- Implement fallback resolver to try GHES first, then GitHub.com
- Update README with GHES configuration examples