### PR TITLE
  Add support for subpath action references

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -20,6 +20,7 @@ func TestApp_Run(t *testing.T) {
 		ref   string
 	}{
 		{"actions", "checkout", "v2"},
+		{"actions", "checkout", "v4"},
 		{"actions", "setup-node", "v1"},
 		{"actions", "setup-go", "v5"},
 		{"actions", "cache", "v4"},

--- a/app_test.go
+++ b/app_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,22 @@ import (
 var updateFlag = flag.Bool("update", false, "update fixture files")
 
 func TestApp_Run(t *testing.T) {
+	expectedArgs := []struct {
+		owner string
+		repo  string
+		ref   string
+	}{
+		{"actions", "checkout", "v2"},
+		{"actions", "setup-node", "v1"},
+		{"actions", "setup-go", "v5"},
+		{"actions", "cache", "v4"},
+	}
 	mockCommitHashResolver := func(ctx context.Context, owner, repo, ref string) (string, error) {
+		if !slices.ContainsFunc(expectedArgs, func(e struct{ owner, repo, ref string }) bool {
+			return e.owner == owner && e.repo == repo && e.ref == ref
+		}) {
+			t.Errorf("unexpected call to CommitHashResolver with owner=%s, repo=%s, ref=%s", owner, repo, ref)
+		}
 		return "mockedCommitHash", nil
 	}
 
@@ -36,6 +52,7 @@ func TestApp_Run(t *testing.T) {
 		"workflows/workflow1.yaml",
 		"workflows/workflow2.yaml",
 		"workflows/workflow3.yaml",
+		"workflows/subdir.yaml",
 	}
 	replacedFiles := app.ReplacedFiles()
 	require.ElementsMatch(t, expectedFiles, replacedFiles)

--- a/testdata/.github/workflows/subdir.yaml
+++ b/testdata/.github/workflows/subdir.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
 
     - name: Restore cached Primes
       id: cache-primes-restore

--- a/testdata/.github/workflows/subdir.yaml
+++ b/testdata/.github/workflows/subdir.yaml
@@ -1,0 +1,28 @@
+name: Caching Primes
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Restore cached Primes
+      id: cache-primes-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          path/to/dependencies
+          some/other/dependencies
+        key: ${{ runner.os }}-primes
+
+    - name: Save Primes
+      id: cache-primes-save
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          path/to/dependencies
+          some/other/dependencies
+        key: ${{ steps.cache-primes-restore.outputs.cache-primary-key }}

--- a/testdata/fixture/workflows/subdir.yaml
+++ b/testdata/fixture/workflows/subdir.yaml
@@ -1,0 +1,28 @@
+name: Caching Primes
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@mockedCommitHash # v4
+
+    - name: Restore cached Primes
+      id: cache-primes-restore
+      uses: actions/cache/restore@mockedCommitHash # v4
+      with:
+        path: |
+          path/to/dependencies
+          some/other/dependencies
+        key: ${{ runner.os }}-primes
+
+    - name: Save Primes
+      id: cache-primes-save
+      uses: actions/cache/save@mockedCommitHash # v4
+      with:
+        path: |
+          path/to/dependencies
+          some/other/dependencies
+        key: ${{ steps.cache-primes-restore.outputs.cache-primary-key }}

--- a/testdata/fixture/workflows/subdir.yaml
+++ b/testdata/fixture/workflows/subdir.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@mockedCommitHash # v4
+    - uses: actions/checkout@mockedCommitHash # v2
 
     - name: Restore cached Primes
       id: cache-primes-restore


### PR DESCRIPTION
 ref #32 by adding support for `owner/repo/path@ref` format actions like `actions/cache/restore@v4`.

  Changes:
  - Parse subpath from action references
  - Handle subpath in replacement logic
  - Add test coverage for cache actions

  This resolves 404 errors when using cache restore/save actions.